### PR TITLE
questhelper: fix known broken quests

### DIFF
--- a/questhelper/questhelper.gradle.kts
+++ b/questhelper/questhelper.gradle.kts
@@ -23,7 +23,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.6"
+version = "0.0.7"
 
 project.extra["PluginName"] = "Quest Helper"
 project.extra["PluginDescription"] = "An in-game interactive guide for quests"

--- a/questhelper/src/main/java/com/questhelper/panel/QuestStepPanel.java
+++ b/questhelper/src/main/java/com/questhelper/panel/QuestStepPanel.java
@@ -169,21 +169,24 @@ public class QuestStepPanel extends JPanel
 
 		for (QuestStep step : panelDetails.getSteps())
 		{
-			if (!step.isShowInSidebar())
+			if (step != null)
 			{
-				steps.put(step, null);
-				continue;
+				if (!step.isShowInSidebar())
+				{
+					steps.put(step, null);
+					continue;
+				}
+
+				JLabel questStepLabel = new JLabel();
+				questStepLabel.setLayout(new BorderLayout());
+				questStepLabel.setBorder(new EmptyBorder(0, 0, 10, 0));
+				questStepLabel.setHorizontalAlignment(SwingConstants.LEFT);
+				questStepLabel.setVerticalAlignment(SwingConstants.TOP);
+				questStepLabel.setText(generateText(step));
+
+				steps.put(step, questStepLabel);
+				questStepsPanel.add(questStepLabel);
 			}
-
-			JLabel questStepLabel = new JLabel();
-			questStepLabel.setLayout(new BorderLayout());
-			questStepLabel.setBorder(new EmptyBorder(0, 0, 10, 0));
-			questStepLabel.setHorizontalAlignment(SwingConstants.LEFT);
-			questStepLabel.setVerticalAlignment(SwingConstants.TOP);
-			questStepLabel.setText(generateText(step));
-
-			steps.put(step, questStepLabel);
-			questStepsPanel.add(questStepLabel);
 		}
 
 		bodyPanel.add(questStepsPanel, BorderLayout.CENTER);

--- a/questhelper/src/main/java/com/questhelper/quests/lunardiplomacy/ChanceChallenge.java
+++ b/questhelper/src/main/java/com/questhelper/quests/lunardiplomacy/ChanceChallenge.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import javax.inject.Inject;
+import net.runelite.api.Client;
 import net.runelite.api.NpcID;
 import net.runelite.api.NullObjectID;
 import net.runelite.api.coords.WorldPoint;
@@ -21,9 +22,6 @@ import net.runelite.client.eventbus.Subscribe;
 
 public class ChanceChallenge extends DetailedOwnerStep
 {
-	@Inject
-	EventBus eventBus;
-
 	DetailedQuestStep talk, spinD1, spinD2, spinD3, spinD4, spinD5, spinD6;
 
 	int currentGoal;
@@ -34,6 +32,11 @@ public class ChanceChallenge extends DetailedOwnerStep
 	{
 		super(questHelper, "Flip the dice to sum up to the correct number.");
 		setupSolutions();
+	}
+
+	public void subscribe()
+	{
+		eventBus.subscribe(GameTick.class, this, this::onGameTick);
 	}
 
 	public void setupSolutions()
@@ -70,7 +73,6 @@ public class ChanceChallenge extends DetailedOwnerStep
 		spinD4 = new ObjectStep(getQuestHelper(), NullObjectID.NULL_17020, new WorldPoint(1732, 5060, 2), "Flip the south west die.");
 		spinD5 = new ObjectStep(getQuestHelper(), NullObjectID.NULL_17022, new WorldPoint(1739, 5067, 2), "Flip the north east die.");
 		spinD6 = new ObjectStep(getQuestHelper(), NullObjectID.NULL_17021, new WorldPoint(1739, 5060, 2), "Flip the south east die.");
-		eventBus.subscribe(GameTick.class, this, this::onGameTick);
 	}
 
 	@Subscribe
@@ -194,5 +196,6 @@ public class ChanceChallenge extends DetailedOwnerStep
 	{
 		return Collections.singletonList(talk);
 	}
+
 }
 

--- a/questhelper/src/main/java/com/questhelper/quests/lunardiplomacy/MemoryChallenge.java
+++ b/questhelper/src/main/java/com/questhelper/quests/lunardiplomacy/MemoryChallenge.java
@@ -12,13 +12,10 @@ import net.runelite.client.eventbus.Subscribe;
 
 public class MemoryChallenge extends DetailedQuestStep
 {
-
-	@Inject
-	EventBus eventBus;
-
-	public MemoryChallenge(QuestHelper questHelper)
+	public MemoryChallenge(QuestHelper questHelper, EventBus eventBus)
 	{
 		super(questHelper, "Follow the path to the end.");
+		eventBus.subscribe(VarbitChanged.class, this, this::onVarbitChanged);
 	}
 
 	@Override
@@ -26,7 +23,6 @@ public class MemoryChallenge extends DetailedQuestStep
 	{
 		super.startUp();
 		setupPaths();
-		eventBus.subscribe(VarbitChanged.class, this, this::onVarbitChanged);
 	}
 
 	@Subscribe

--- a/questhelper/src/main/java/com/questhelper/quests/lunardiplomacy/MimicChallenge.java
+++ b/questhelper/src/main/java/com/questhelper/quests/lunardiplomacy/MimicChallenge.java
@@ -34,6 +34,7 @@ import com.questhelper.steps.emote.QuestEmote;
 import java.util.Arrays;
 import java.util.Collection;
 import javax.inject.Inject;
+import net.runelite.api.Client;
 import net.runelite.api.NpcID;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.VarbitChanged;
@@ -42,9 +43,6 @@ import net.runelite.client.eventbus.Subscribe;
 
 public class MimicChallenge extends DetailedOwnerStep
 {
-	@Inject
-	EventBus eventBus;
-
 	DetailedQuestStep cry, bow, dance, wave, think, talk;
 
 	public MimicChallenge(QuestHelper questHelper)
@@ -61,6 +59,11 @@ public class MimicChallenge extends DetailedOwnerStep
 		think = new EmoteStep(getQuestHelper(), QuestEmote.THINK, new WorldPoint(1772, 5070, 2), "Perform the think emote.");
 		talk = new NpcStep(getQuestHelper(), NpcID.ETHEREAL_MIMIC, "Talk to the Ethereal Mimic.");
 		talk.addDialogStep("Suppose I may as well have a go.");
+	}
+
+
+	public void subscribe()
+	{
 		eventBus.subscribe(VarbitChanged.class, this, this::onVarbitChanged);
 	}
 

--- a/questhelper/src/main/java/com/questhelper/quests/lunardiplomacy/NumberChallenge.java
+++ b/questhelper/src/main/java/com/questhelper/quests/lunardiplomacy/NumberChallenge.java
@@ -8,6 +8,7 @@ import com.questhelper.steps.QuestStep;
 import java.util.Arrays;
 import java.util.Collection;
 import javax.inject.Inject;
+import net.runelite.api.Client;
 import net.runelite.api.ObjectID;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.VarbitChanged;
@@ -16,14 +17,15 @@ import net.runelite.client.eventbus.Subscribe;
 
 public class NumberChallenge extends DetailedOwnerStep
 {
-	@Inject
-	EventBus eventBus;
-
 	DetailedQuestStep press0, press1, press2, press3, press4, press5, press6, press7, press8, press9, catchStep;
 
 	public NumberChallenge(QuestHelper questHelper)
 	{
 		super(questHelper, "Select the correct numbers to finish the pattern.");
+	}
+
+	public void subscribe()
+	{
 		eventBus.subscribe(VarbitChanged.class, this, this::onVarbitChanged);
 	}
 

--- a/questhelper/src/main/java/com/questhelper/quests/rumdeal/SlugSteps.java
+++ b/questhelper/src/main/java/com/questhelper/quests/rumdeal/SlugSteps.java
@@ -38,6 +38,7 @@ import com.questhelper.steps.conditional.ZoneCondition;
 import java.util.Arrays;
 import java.util.Collection;
 import javax.inject.Inject;
+import net.runelite.api.Client;
 import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
@@ -52,9 +53,6 @@ import net.runelite.client.eventbus.Subscribe;
 
 public class SlugSteps extends DetailedOwnerStep
 {
-	@Inject
-	EventBus eventBus;
-
 	DetailedQuestStep addSluglings, talkToPete, goDownFromTop, fish5Slugs, goDownToSluglings, goUpFromSluglings, goUpToDropSluglings, goUpF1ToPressure, goUpToF2ToPressure, pressure;
 	ConditionalStep getSluglings, pressureSluglings, pullPressureLever;
 
@@ -75,6 +73,11 @@ public class SlugSteps extends DetailedOwnerStep
 	public void onGameTick(GameTick event)
 	{
 		updateSteps();
+	}
+
+	public void subscribe()
+	{
+		eventBus.subscribe(GameTick.class, this, this::onGameTick);
 	}
 
 	protected void updateSteps()
@@ -169,8 +172,6 @@ public class SlugSteps extends DetailedOwnerStep
 		pullPressureLever.addStep(onIslandF2, pressure);
 		pullPressureLever.addStep(onIslandF1, goUpToF2ToPressure);
 		pullPressureLever.addStep(onIslandF0, goUpF1ToPressure);
-		eventBus.subscribe(GameTick.class, this, this::onGameTick);
-
 	}
 
 	@Override

--- a/questhelper/src/main/java/com/questhelper/quests/shadowofthestorm/SearchKilns.java
+++ b/questhelper/src/main/java/com/questhelper/quests/shadowofthestorm/SearchKilns.java
@@ -31,6 +31,7 @@ import com.questhelper.steps.QuestStep;
 import java.util.Arrays;
 import java.util.Collection;
 import javax.inject.Inject;
+import net.runelite.api.Client;
 import net.runelite.api.NullObjectID;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.GameTick;
@@ -39,14 +40,16 @@ import net.runelite.client.eventbus.Subscribe;
 
 public class SearchKilns extends DetailedOwnerStep
 {
-	@Inject
-	EventBus eventBus;
-
 	ObjectStep searchKiln1, searchKiln2, searchKiln3, searchKiln4;
 
 	public SearchKilns(QuestHelper questHelper)
 	{
 		super(questHelper, "Search the kilns in Uzer until you find a book.");
+	}
+
+	public void subscribe()
+	{
+		eventBus.subscribe(GameTick.class, this, this::onGameTick);
 	}
 
 	@Subscribe
@@ -84,8 +87,6 @@ public class SearchKilns extends DetailedOwnerStep
 		searchKiln2 = new ObjectStep(getQuestHelper(), NullObjectID.NULL_10243, new WorldPoint(3479, 3083, 0), "Search the kilns in Uzer until you find a book.");
 		searchKiln3 = new ObjectStep(getQuestHelper(), NullObjectID.NULL_10244, new WorldPoint(3473, 3093, 0), "Search the kilns in Uzer until you find a book.");
 		searchKiln4 = new ObjectStep(getQuestHelper(), NullObjectID.NULL_10245, new WorldPoint(3501, 3085, 0), "Search the kilns in Uzer until you find a book.");
-		eventBus.subscribe(GameTick.class, this, this::onGameTick);
-
 	}
 
 	@Override

--- a/questhelper/src/main/java/com/questhelper/quests/shadowofthestorm/ShadowOfTheStorm.java
+++ b/questhelper/src/main/java/com/questhelper/quests/shadowofthestorm/ShadowOfTheStorm.java
@@ -24,6 +24,7 @@
  */
 package com.questhelper.quests.shadowofthestorm;
 
+import com.google.inject.Inject;
 import com.questhelper.QuestDescriptor;
 import com.questhelper.QuestHelperQuest;
 import com.questhelper.Zone;
@@ -49,17 +50,30 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import net.runelite.api.Client;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.NullObjectID;
 import net.runelite.api.ObjectID;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.events.GameTick;
+import net.runelite.client.eventbus.EventBus;
+import net.runelite.client.eventbus.Subscribe;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.SHADOW_OF_THE_STORM
 )
 public class ShadowOfTheStorm extends BasicQuestHelper
 {
+	@Inject
+	EventBus eventBus;
+
+	@Inject
+	Client client;
+
+	SearchKilns searchKiln = new SearchKilns(this);
+	boolean searchKilnSubscribed = false;
+
 	ItemRequirement darkItems, silverlight, strangeImplement, blackMushroomInk, pestle, vial, silverBar, silverlightHighlighted, blackMushroomHighlighted,
 		silverlightDyedEquipped, sigilMould, silverlightDyed, strangeImplementHighlighted, combatGear, coinsForCarpet, sigil, book, bookHighlighted,
 		sigilHighlighted, sigil2;
@@ -78,13 +92,27 @@ public class ShadowOfTheStorm extends BasicQuestHelper
 		standInCircleAgain, enterRuinNoDark, enterRuinForRitual, enterPortalForRitual, enterRuinForDave, enterPortalForFight,
 		enterRuinForFight, unequipDarklight;
 
-	DetailedOwnerStep searchKiln;
-
 	IncantationStep readIncantation, incantRitual;
+
+	@Subscribe
+	public void onGameTick(GameTick event)
+	{
+		if (eventBus != null && client != null)
+		{
+			if (!searchKilnSubscribed)
+			{
+				searchKiln.eventBus = eventBus;
+				searchKiln.client = client;
+				searchKiln.subscribe();
+				searchKilnSubscribed = true;
+			}
+		}
+	}
 
 	@Override
 	public Map<Integer, QuestStep> loadSteps()
 	{
+		eventBus.subscribe(GameTick.class, this, this::onGameTick);
 		Map<Integer, QuestStep> steps = new HashMap<>();
 		setupZones();
 		setupItemRequirements();
@@ -261,7 +289,6 @@ public class ShadowOfTheStorm extends BasicQuestHelper
 		smeltSigil = new DetailedQuestStep(this, "Travel to any furnace with the sigil mould and silver bar and smelt a sigil.", silverBar, sigilMould);
 		talkToGolem = new NpcStep(this, NpcID.CLAY_GOLEM_5136, new WorldPoint(3485, 3088, 0), "Talk to the Golem in Uzer.", silverlightDyed, sigil, combatGear);
 		talkToGolem.addDialogStep("Did you see anything happen last night?");
-		searchKiln = new SearchKilns(this);
 		readBook = new DetailedQuestStep(this, "Read the book.", bookHighlighted);
 		enterRuinAfterBook = new ObjectStep(this, ObjectID.STAIRCASE_6373, new WorldPoint(3493, 3090, 0), "Enter the Uzer ruins.", silverlightDyed, book, sigil);
 		enterPortalAfterBook = new ObjectStep(this, NullObjectID.NULL_6310, new WorldPoint(2722, 4913, 0), "Enter the portal.", book, sigil);

--- a/questhelper/src/main/java/com/questhelper/quests/sinsofthefather/DoorPuzzleStep.java
+++ b/questhelper/src/main/java/com/questhelper/quests/sinsofthefather/DoorPuzzleStep.java
@@ -45,10 +45,6 @@ import net.runelite.client.ui.overlay.components.PanelComponent;
 
 public class DoorPuzzleStep extends DetailedQuestStep
 {
-	@Inject
-	Client client;
-
-	@Inject
 	EventBus eventBus;
 
 	private final int UNKNOWN_VALUE = 0;
@@ -95,6 +91,11 @@ public class DoorPuzzleStep extends DetailedQuestStep
 	public DoorPuzzleStep(BasicQuestHelper questHelper)
 	{
 		super(questHelper, "Solve the puzzle by marking the highlighted squares.");
+	}
+
+	public void subscribe()
+	{
+		eventBus.subscribe(GameTick.class, this, this::onGameTick);
 	}
 
 	private PuzzleLine[] solve()
@@ -425,8 +426,6 @@ public class DoorPuzzleStep extends DetailedQuestStep
 		allSolutions.put(13, getSolutions(new PuzzleLine(FILLED, EMPTY, FILLED, FILLED, FILLED)));
 		allSolutions.put(14, getSolutions(new PuzzleLine(EMPTY, FILLED, FILLED, FILLED, FILLED)));
 		allSolutions.put(15, getSolutions(new PuzzleLine(FILLED, FILLED, FILLED, FILLED, FILLED)));
-
-		eventBus.subscribe(GameTick.class, this, this::onGameTick);
 
 		return allSolutions;
 	}

--- a/questhelper/src/main/java/com/questhelper/quests/sinsofthefather/SinsOfTheFather.java
+++ b/questhelper/src/main/java/com/questhelper/quests/sinsofthefather/SinsOfTheFather.java
@@ -24,6 +24,7 @@
  */
 package com.questhelper.quests.sinsofthefather;
 
+import com.google.inject.Inject;
 import com.questhelper.ItemCollections;
 import com.questhelper.QuestDescriptor;
 import com.questhelper.QuestHelperQuest;
@@ -52,24 +53,39 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import net.runelite.api.Client;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.NullObjectID;
 import net.runelite.api.ObjectID;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.events.GameTick;
+import net.runelite.client.eventbus.EventBus;
+import net.runelite.client.eventbus.Subscribe;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.SINS_OF_THE_FATHER
 )
 public class SinsOfTheFather extends BasicQuestHelper
 {
+	@Inject
+	EventBus eventBus;
+
+	@Inject
+	Client client;
+
+	DoorPuzzleStep doDoorPuzzle= new DoorPuzzleStep(this);
+	boolean doDoorPuzzleSubscribed = false;
+	ValveStep valveStep = new ValveStep(this);
+	boolean valveStepSubscribed = false;
+
 	QuestStep startQuest, talkToHameln, talkToCarl, inspectBarrel, followCarl, killKroy, destroyLab, talkToVeliafAfterKroy, talkToVeliafInPater,
 		talkToIvan, listenToMeeting, talkToIvanAfterMeeting, talkToIvanAfterTrek, talkToVeliafInBoatHouse, travelToGraveyard, talkToVeliafInGraveyard, talkToVanescula,
 		talkToVanesculaAfterPuzzle, talkToVanesculaAfterTeam, talkToSafalaanInLab, killBloodveld, talkToSafalaanInDeepLab, searchLabBookcase,
 		takeBookToSafalaan, talkToVanesculaAfterLab, talkToPolmafi, talkToPolmafiMore, bringUnscentedToVanescula, talkToVeliafForFight, killDamien, talkToVeliafAfterDamien,
 		talkToVanesculaAfterDamien, enterDarkmeyer, talkToDesmodus, talkToMordan, talkToMaria, talkToDesmodusAgain, getNote, bringVanesculaLogs, bringVertidaLogs,
 		talkToVertidaForFlail, talkToVanesculaWithFlail, talkToSafalaanWithFlail, talkToVanesculaBeforeFight, talkToVanesculaForFight, talkToVeliafAfterFight,
-		finishQuest, templeTrek, talkToTeamSteps, valveStep, createFlailSteps, doDoorPuzzle, cutLogs, goDownToKroy, destroyLab2, enterPater, killJuvinates,
+		finishQuest, templeTrek, talkToTeamSteps, createFlailSteps, cutLogs, goDownToKroy, destroyLab2, enterPater, killJuvinates,
 		leaveJuvinateArea, openPuzzleDoor, goToLab, enterDeepLab, goDownToPolmafi, goDownToPolmafiNoItems, talkToVeliafForFinalFight, readNote,
 		goDownToVerditaWithLogs, fightVanstrom, enterBaseToFinish;
 
@@ -92,9 +108,31 @@ public class SinsOfTheFather extends BasicQuestHelper
 		inJuvinateArea, juvinateNearby, inPuzzleInterface, talkedToKael, talkedToVertida, talkedToPolmafi, talkedToRadigad, talkedToIvan, inLab, inDeepLab, inNewBase,
 		inDamienRoom, hasNote, hasSickle, hasRubySickle, hasEnchantedRubySickle, hasBlisterwoodSickle, inFinalFightArea;
 
+	@Subscribe
+	public void onGameTick(GameTick event)
+	{
+		if (eventBus != null && client != null)
+		{
+			if (!doDoorPuzzleSubscribed)
+			{
+				doDoorPuzzle.eventBus = eventBus;
+				doDoorPuzzle.client = client;
+				doDoorPuzzle.subscribe();
+				doDoorPuzzleSubscribed = true;
+			}
+			if (!valveStepSubscribed)
+			{
+				valveStep.eventBus = eventBus;
+				valveStep.client = client;
+				valveStep.subscribe();
+				valveStepSubscribed = true;
+			}
+		}
+	}
 	@Override
 	public Map<Integer, QuestStep> loadSteps()
 	{
+		eventBus.subscribe(GameTick.class, this, this::onGameTick);
 		Map<Integer, QuestStep> steps = new HashMap<>();
 		setupZones();
 		setupItemRequirements();
@@ -791,9 +829,7 @@ public class SinsOfTheFather extends BasicQuestHelper
 		templeTrek = new NpcStep(this, NpcID.IVAN_STROM_9530, new WorldPoint(3444, 3485, 0),
 			"Speak to Ivan Strom outside the east entrance of Paterdomus to go temple treking with him.");
 		talkToTeamSteps = new DetailedQuestStep(this, "Convince the Myreque to take on Drakan.");
-		valveStep = new ValveStep(this);
 		createFlailSteps = new DetailedQuestStep(this, "Create the blisterwood flail.", blisterwoodFlail);
-		doDoorPuzzle = new DoorPuzzleStep(this);
 	}
 
 	@Override

--- a/questhelper/src/main/java/com/questhelper/quests/sinsofthefather/ValveStep.java
+++ b/questhelper/src/main/java/com/questhelper/quests/sinsofthefather/ValveStep.java
@@ -38,6 +38,7 @@ import java.util.Collection;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.inject.Inject;
+import net.runelite.api.Client;
 import net.runelite.api.ItemID;
 import net.runelite.api.ObjectID;
 import net.runelite.api.coords.WorldPoint;
@@ -48,9 +49,6 @@ import net.runelite.client.eventbus.Subscribe;
 
 public class ValveStep extends DetailedOwnerStep
 {
-	@Inject
-	EventBus eventBus;
-
 	DetailedQuestStep readNote, setNorthValve, setSouthValve, setNorthValveNoHighlight, setSouthValveNoHighlight, cutTree;
 
 	private int valveTotalValue;
@@ -77,6 +75,11 @@ public class ValveStep extends DetailedOwnerStep
 	public ValveStep(QuestHelper questHelper)
 	{
 		super(questHelper, "Turn the valves to solve the water puzzle.");
+	}
+
+	public void subscribe()
+	{
+		eventBus.subscribe(GameTick.class, this, this::onGameTick);
 	}
 
 	@Override
@@ -270,8 +273,6 @@ public class ValveStep extends DetailedOwnerStep
 
 		cutTree = new ObjectStep(getQuestHelper(), ObjectID.BLISTERWOOD_TREE, new WorldPoint(3635, 3362, 0),
 			"Gather 8 logs from the Blisterwood tree.", scentedTop, scentedLegs, scentedShoes);
-
-		eventBus.subscribe(GameTick.class, this, this::onGameTick);
 	}
 
 	@Override

--- a/questhelper/src/main/java/com/questhelper/quests/swansong/FishMonkfish.java
+++ b/questhelper/src/main/java/com/questhelper/quests/swansong/FishMonkfish.java
@@ -34,6 +34,7 @@ import com.questhelper.steps.QuestStep;
 import java.util.Arrays;
 import java.util.Collection;
 import javax.inject.Inject;
+import net.runelite.api.Client;
 import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
@@ -48,10 +49,8 @@ import net.runelite.client.eventbus.Subscribe;
 
 public class FishMonkfish extends DetailedOwnerStep
 {
-	@Inject
-	EventBus eventBus;
-
-	DetailedQuestStep fishMonkfish, cookMonkfish, talkToArnoldWithMonkfish;
+	DetailedQuestStep fishMonkfish;
+	DetailedQuestStep cookMonkfish, talkToArnoldWithMonkfish;
 	ItemRequirement cookedMonkfish = new ItemRequirement("Fresh monkfish", ItemID.FRESH_MONKFISH_7943, 5);
 	ItemRequirement rawMonkfish = new ItemRequirement("Fresh monkfish", ItemID.FRESH_MONKFISH, 5);
 	ItemRequirement combatGear = new ItemRequirement("Combat gear", -1, -1);
@@ -62,6 +61,12 @@ public class FishMonkfish extends DetailedOwnerStep
 	{
 		super(questHelper);
 		smallNet.setTip("You can get one from Arnold");
+		fishMonkfish = new ObjectStep(getQuestHelper(), NullObjectID.NULL_13477, new WorldPoint(2311, 3696, 0), "Fish at least 5 fresh monkfish. Sea Trolls will appear, and you'll need to kill them.", smallNet, combatGear);
+	}
+
+	public void subscribe()
+	{
+		eventBus.subscribe(GameTick.class, this, this::onGameTick);
 	}
 
 	@Subscribe
@@ -112,11 +117,8 @@ public class FishMonkfish extends DetailedOwnerStep
 	@Override
 	protected void setupSteps()
 	{
-		fishMonkfish = new ObjectStep(getQuestHelper(), NullObjectID.NULL_13477, new WorldPoint(2311, 3696, 0), "Fish at least 5 fresh monkfish. Sea Trolls will appear, and you'll need to kill them.", smallNet, combatGear);
 		cookMonkfish = new ObjectStep(getQuestHelper(), ObjectID.RANGE_12611, new WorldPoint(2316, 3669, 0), "Cook 5 monkfish. If you burn any, catch some more.", rawMonkfish);
 		talkToArnoldWithMonkfish = new NpcStep(getQuestHelper(), NpcID.ARNOLD_LYDSPOR, new WorldPoint(2329, 3688, 0), "Bring the monkfish to Arnold at the bank.", cookedMonkfish);
-
-		eventBus.subscribe(GameTick.class, this, this::onGameTick);
 	}
 
 	@Override

--- a/questhelper/src/main/java/com/questhelper/quests/swansong/FixWall.java
+++ b/questhelper/src/main/java/com/questhelper/quests/swansong/FixWall.java
@@ -33,6 +33,7 @@ import com.questhelper.steps.QuestStep;
 import java.util.Arrays;
 import java.util.Collection;
 import javax.inject.Inject;
+import net.runelite.api.Client;
 import net.runelite.api.ItemID;
 import net.runelite.api.NullObjectID;
 import net.runelite.api.coords.WorldPoint;
@@ -42,9 +43,6 @@ import net.runelite.client.eventbus.Subscribe;
 
 public class FixWall extends DetailedOwnerStep
 {
-	@Inject
-	EventBus eventBus;
-
 	DetailedQuestStep useIronBar, repairWall1, repairWall2, repairWall3, repairWall4, repairWall5;
 
 	ItemRequirement ironSheets, ironBars, hammer;
@@ -52,6 +50,11 @@ public class FixWall extends DetailedOwnerStep
 	public FixWall(QuestHelper questHelper)
 	{
 		super(questHelper);
+	}
+
+	public void subscribe()
+	{
+		eventBus.subscribe(GameTick.class, this, this::onGameTick);
 	}
 
 	@Subscribe
@@ -125,7 +128,6 @@ public class FixWall extends DetailedOwnerStep
 		repairWall5 = new ObjectStep(getQuestHelper(), NullObjectID.NULL_13700, new WorldPoint(2311, 3684, 0), "Repair the west wall.", ironSheets, hammer);
 		repairWall5.addIcon(ItemID.IRON_SHEET);
 		repairWall1.addSubSteps(repairWall2, repairWall3, repairWall4, repairWall5);
-		eventBus.subscribe(GameTick.class, this, this::onGameTick);
 	}
 
 	@Override

--- a/questhelper/src/main/java/com/questhelper/quests/swansong/SwanSong.java
+++ b/questhelper/src/main/java/com/questhelper/quests/swansong/SwanSong.java
@@ -24,6 +24,7 @@
  */
 package com.questhelper.quests.swansong;
 
+import com.google.inject.Inject;
 import com.questhelper.QuestDescriptor;
 import com.questhelper.QuestHelperQuest;
 import com.questhelper.Zone;
@@ -47,17 +48,31 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import net.runelite.api.Client;
 import net.runelite.api.ItemID;
 import net.runelite.api.NpcID;
 import net.runelite.api.NullObjectID;
 import net.runelite.api.ObjectID;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.events.GameTick;
+import net.runelite.client.eventbus.EventBus;
+import net.runelite.client.eventbus.Subscribe;
 
 @QuestDescriptor(
 	quest = QuestHelperQuest.SWAN_SONG
 )
 public class SwanSong extends BasicQuestHelper
 {
+	@Inject
+	EventBus eventBus;
+
+	@Inject
+	Client client;
+
+	boolean repairWallSubscribed = false;
+	boolean fishAndCookMonkfishSubscribed = false;
+
+
 	ItemRequirement mist10, lava10, blood5, bones7, pot, potLid, ironBar5, log, tinderbox, hammer, brownApron, monkfish5, rawMonkfish5, combatGear, potHiglight,
 		potLidHiglight, tinderboxHiglight, ironBar5Higlight, logHiglight, ironSheet5, smallNet, airtightPot, combatGearRanged, boneSeeds;
 
@@ -68,15 +83,38 @@ public class SwanSong extends BasicQuestHelper
 		talkToFranklinAgain, talkToHermanAfterTasks, enterWizardsBasement, talkToFruscone, talkToMalignius, talkToCrafter, makeAirtightPot, talkToMaligniusWithPot,
 		talkToHermanForFinalFight, killQueen, talkToHermanToFinish, talkToHermanWithPot;
 
-	FixWall repairWall;
+	FixWall repairWall = new FixWall(this);
 
-	FishMonkfish fishAndCookMonkfish;
+	FishMonkfish fishAndCookMonkfish = new FishMonkfish(this);
 
 	Zone colonyEntrance, basement;
+
+	@Subscribe
+	public void onGameTick(GameTick event)
+	{
+		if (eventBus != null && client != null)
+		{
+			if (!repairWallSubscribed)
+			{
+				repairWall.eventBus = eventBus;
+				repairWall.client = client;
+				repairWall.subscribe();
+				repairWallSubscribed = true;
+			}
+			if (!fishAndCookMonkfishSubscribed)
+			{
+				fishAndCookMonkfish.eventBus = eventBus;
+				fishAndCookMonkfish.client = client;
+				fishAndCookMonkfish.subscribe();
+				fishAndCookMonkfishSubscribed = true;
+			}
+		}
+	}
 
 	@Override
 	public Map<Integer, QuestStep> loadSteps()
 	{
+		eventBus.subscribe(GameTick.class, this, this::onGameTick);
 		loadZones();
 		setupItemRequirements();
 		setupConditions();
@@ -235,10 +273,8 @@ public class SwanSong extends BasicQuestHelper
 		useLog.addIcon(ItemID.LOGS);
 		useTinderbox = new ObjectStep(this, NullObjectID.NULL_13702, new WorldPoint(2344, 3676, 0), "Light the logs in the firebox in the building with a furnace.", tinderboxHiglight);
 		useTinderbox.addIcon(ItemID.TINDERBOX);
-		repairWall = new FixWall(this);
 
 		talkToArnold = new NpcStep(this, NpcID.ARNOLD_LYDSPOR, new WorldPoint(2329, 3688, 0), "Talk to Arnold at the bank in the Fishing Colony.");
-		fishAndCookMonkfish = new FishMonkfish(this);
 
 		talkToFranklinAgain = new NpcStep(this, NpcID.FRANKLIN_CARANOS, new WorldPoint(2341, 3667, 0), "Talk to Franklin again.");
 		talkToHermanAfterTasks = new NpcStep(this, NpcID.HERMAN_CARANOS, new WorldPoint(2354, 3683, 0), "Talk to the Herman in the east of the colony again.");

--- a/questhelper/src/main/java/com/questhelper/quests/theforsakentower/AltarPuzzle.java
+++ b/questhelper/src/main/java/com/questhelper/quests/theforsakentower/AltarPuzzle.java
@@ -29,11 +29,7 @@ import net.runelite.client.ui.overlay.components.PanelComponent;
 
 public class AltarPuzzle extends QuestStep implements OwnerStep
 {
-	@Inject
-	protected EventBus eventBus;
-
-	@Inject
-	protected Client client;
+	EventBus eventBus;
 
 	private QuestStep currentStep;
 
@@ -57,6 +53,11 @@ public class AltarPuzzle extends QuestStep implements OwnerStep
 		setupZones();
 		setupConditions();
 		setupSteps();
+	}
+
+	public void subscribe()
+	{
+		eventBus.subscribe(GameTick.class, this, this::onGameTick);
 	}
 
 	@Override
@@ -379,8 +380,6 @@ public class AltarPuzzle extends QuestStep implements OwnerStep
 		m15.addSubSteps(rebalanceE.get(9), rebalanceC.get(9));
 
 		restartStep = new DetailedQuestStep(getQuestHelper(), "Unknown state. Restart the puzzle to start again.");
-
-		eventBus.subscribe(GameTick.class, this, this::onGameTick);
 	}
 
 	public ArrayList<PanelDetails> panelDetails()

--- a/questhelper/src/main/java/com/questhelper/quests/theforsakentower/JugPuzzle.java
+++ b/questhelper/src/main/java/com/questhelper/quests/theforsakentower/JugPuzzle.java
@@ -42,11 +42,9 @@ public class JugPuzzle extends QuestStep implements OwnerStep
 	private static final Pattern JUG_EMPTIED = Pattern.compile("^You empty the ([0-9])-gallon jug");
 	private static final Pattern JUG_CHECKED = Pattern.compile("^The ([0-9])-gallon jug(?: contains ([0-9]) gallons* of coolant| is empty)");
 
-	@Inject
-	protected EventBus eventBus;
 
-	@Inject
-	protected Client client;
+	EventBus eventBus;
+
 
 	protected QuestStep currentStep;
 
@@ -66,11 +64,15 @@ public class JugPuzzle extends QuestStep implements OwnerStep
 		super(questHelper, "");
 		jugs.put("5", -1);
 		jugs.put("8", -1);
-
 		setupItemRequirements();
 		setupZones();
 		setupConditions();
 		setupSteps();
+	}
+
+	public void subscribe()
+	{
+		eventBus.subscribe(GameTick.class, this, this::onGameTick);
 	}
 
 	@Override
@@ -351,9 +353,6 @@ public class JugPuzzle extends QuestStep implements OwnerStep
 		goDownToFirstFloor = new ObjectStep(getQuestHelper(), ObjectID.LADDER_33485, new WorldPoint(1382, 3827, 2), "Go down from the top floor.");
 		goDownToGroundFloor = new ObjectStep(getQuestHelper(), ObjectID.STAIRCASE_33552, new WorldPoint(1378, 3825, 1), "Go down to the ground floor.");
 		goUpToGroundFloor = new ObjectStep(getQuestHelper(), ObjectID.LADDER_33484, new WorldPoint(1382, 10229, 0), "Leave the tower's basement.");
-
-		eventBus.subscribe(GameTick.class, this, this::onGameTick);
-
 	}
 
 	public ArrayList<PanelDetails> panelDetails()

--- a/questhelper/src/main/java/com/questhelper/quests/theforsakentower/PotionPuzzle.java
+++ b/questhelper/src/main/java/com/questhelper/quests/theforsakentower/PotionPuzzle.java
@@ -35,11 +35,7 @@ import net.runelite.client.ui.overlay.components.PanelComponent;
 
 public class PotionPuzzle extends QuestStep implements OwnerStep
 {
-	@Inject
-	protected EventBus eventBus;
-
-	@Inject
-	protected Client client;
+	EventBus eventBus;
 
 	// Potion 1
 	private static final Pattern LINE1 = Pattern.compile("^(.*) blend is directly");
@@ -76,12 +72,16 @@ public class PotionPuzzle extends QuestStep implements OwnerStep
 		setupSteps();
 	}
 
+	public void subscribe()
+	{
+		eventBus.subscribe(GameTick.class, this, this::onGameTick);
+		eventBus.subscribe(WidgetLoaded.class, this, this::onWidgetLoaded);
+	}
+
 	@Override
 	public void startUp()
 	{
 		updateSteps();
-		eventBus.subscribe(GameTick.class, this, this::onGameTick);
-		eventBus.subscribe(WidgetLoaded.class, this, this::onWidgetLoaded);
 	}
 
 	@Override
@@ -226,7 +226,6 @@ public class PotionPuzzle extends QuestStep implements OwnerStep
 		fluid4.setHighlightInInventory(true);
 		fluid5 = new ItemRequirement("Unknown fluid 5", ItemID.UNKNOWN_FLUID_5);
 		fluid5.setHighlightInInventory(true);
-
 		fluids = new ItemRequirement[]{null, fluid1, fluid2, fluid3, fluid4, fluid5};
 	}
 

--- a/questhelper/src/main/java/com/questhelper/quests/theforsakentower/PowerPuzzle.java
+++ b/questhelper/src/main/java/com/questhelper/quests/theforsakentower/PowerPuzzle.java
@@ -5,13 +5,17 @@ import com.questhelper.questhelpers.QuestHelper;
 import com.questhelper.steps.QuestStep;
 import java.awt.Color;
 import java.awt.Graphics2D;
+import net.runelite.api.Client;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.widgets.Widget;
+import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 
 /* Possible improvement would be to show a number on each square indicating turns remaining to solved position */
 public class PowerPuzzle extends QuestStep
 {
+	EventBus eventBus;
+
 	int[] solvedPositions =
 		{
 			0, 0, 1, 0, 4, 1,
@@ -27,6 +31,11 @@ public class PowerPuzzle extends QuestStep
 	public PowerPuzzle(QuestHelper questHelper)
 	{
 		super(questHelper, "Click the highlighted boxes to turn the squares to solve the puzzle.");
+	}
+
+	public void subscribe()
+	{
+		eventBus.subscribe(VarbitChanged.class, this, this::onVarbitChanged);
 	}
 
 	@Override

--- a/questhelper/src/main/java/com/questhelper/steps/DetailedOwnerStep.java
+++ b/questhelper/src/main/java/com/questhelper/steps/DetailedOwnerStep.java
@@ -43,10 +43,10 @@ public class DetailedOwnerStep extends QuestStep implements OwnerStep
 	protected Requirement[] requirements;
 
 	@Inject
-	protected EventBus eventBus;
+	public EventBus eventBus;
 
 	@Inject
-	protected Client client;
+	public Client client;
 
 	public DetailedOwnerStep(QuestHelper questHelper, Requirement... requirements)
 	{

--- a/questhelper/src/main/java/com/questhelper/steps/QuestStep.java
+++ b/questhelper/src/main/java/com/questhelper/steps/QuestStep.java
@@ -60,7 +60,7 @@ import net.runelite.client.util.ImageUtil;
 public abstract class QuestStep implements Module
 {
 	@Inject
-	protected Client client;
+	public Client client;
 
 	@Inject
 	private ClientThread clientThread;


### PR DESCRIPTION
This fixes the following quests:  
  
```
Lunar Diplomacy  
Rum Deal  
Shadow of the Storm  
Sins of the Father  
Swan Song  
The Forsaken Tower  
```
  
There may be more quests broken, but I didn't have the ability to test some of the later quests.  
If you find a quest that crashes the plugin when started, please PM me directly, or create an issue.