### PR TITLE
questhelper: fix startup crashes

### DIFF
--- a/questhelper/questhelper.gradle.kts
+++ b/questhelper/questhelper.gradle.kts
@@ -23,7 +23,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.8"
+version = "0.0.9"
 
 project.extra["PluginName"] = "Quest Helper"
 project.extra["PluginDescription"] = "An in-game interactive guide for quests"


### PR DESCRIPTION
This put to rest a rather hard to track bug resulting in startup failures for some.  
  
No OPRS reboot should be required to get plugin going after first install, maaaaybe a logout cycle.