### PR TITLE
collectionlog: fix broken config

### DIFF
--- a/collectionlog/collectionlog.gradle.kts
+++ b/collectionlog/collectionlog.gradle.kts
@@ -23,7 +23,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.1.0"
+version = "0.2.0"
 
 project.extra["PluginProvider"] = "evansloan"
 project.extra["PluginName"] = "Collection Log"

--- a/collectionlog/src/main/java/com/evansloan/collectionlog/CollectionLogPlugin.java
+++ b/collectionlog/src/main/java/com/evansloan/collectionlog/CollectionLogPlugin.java
@@ -466,7 +466,17 @@ public class CollectionLogPlugin extends Plugin
 		String jsonString = configManager.getConfiguration(group, configKey);
 		if (jsonString == null)
 		{
-			return "{}";
+			if (configKey.equals("completed_categories"))
+			{
+				return "[]";  // List<x>
+			}
+			return "{}"; // Map<x,y>
+		}
+		if (configKey.equals("completed_categories") && jsonString.equals("{}"))
+		{
+			log.debug("Detected incorrect value in - completed_categories - overrote it with []");
+			configManager.setConfiguration(group, configKey, "[]");
+			return "[]";  // List<x>
 		}
 		return jsonString;
 	}


### PR DESCRIPTION
I dont know how this is not an issue on runelite maybe different GSON versions or I'm missing something. /shrug

but when you first start this plugin and the configkeys used to store the collectionlog data are blank it defaults them to "{}" 
which is fine for the map types but the completed_categories is a list so needs to be "[]"

these config keys are not in the plugins config so resetting won't fix the broken keys so i've added an override to the plugin.
